### PR TITLE
Handle correctly the error from propagate, and return more useful message

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -395,12 +395,7 @@ class TLEJS {
       throw new Error('TLE could not be parsed:', tle);
     }
 
-    let satInfo;
-    try {
-      satInfo = this.getSatelliteInfo(tleObj.arr, optionalTimestamp);
-    } catch (error) {
-      throw error;
-    }
+    const satInfo = this.getSatelliteInfo(tleObj.arr, optionalTimestamp);
     return {
       lat: satInfo.lat,
       lng: satInfo.lng

--- a/src/main.js
+++ b/src/main.js
@@ -395,7 +395,12 @@ class TLEJS {
       throw new Error('TLE could not be parsed:', tle);
     }
 
-    const satInfo = this.getSatelliteInfo(tleObj.arr, optionalTimestamp);
+    let satInfo;
+    try {
+      satInfo = this.getSatelliteInfo(tleObj.arr, optionalTimestamp);
+    } catch (error) {
+      throw error;
+    }
     return {
       lat: satInfo.lat,
       lng: satInfo.lng

--- a/src/main.js
+++ b/src/main.js
@@ -324,10 +324,17 @@ class TLEJS {
     // Propagate SGP4.
     const positionAndVelocity = satellitejs.propagate(satrec, time);
 
-    if (satellitejs.error) {
-      throw new Error('Error: problematic TLE with unexpected eccentricity');
+   if (satrec.error) {
+      const errorMessages = {
+        1: 'mean elements, ecc >= 1.0 or ecc < -0.001 or a < 0.95 er',
+        2: 'mean motion less than 0.0',
+        3: 'pert elements, ecc < 0.0  or  ecc > 1.0',
+        4: 'semi-latus rectum < 0.0',
+        5: 'epoch elements are sub-orbital',
+        6: 'satellite has decayed'
+      }
+      throw new Error(errorMessages[satrec.error] || 'Error: problematic TLE with unexpected eccentricity')
     }
-
     // The position_velocity result is a key-value pair of ECI coordinates.
     // These are the base results from which all other coordinates are derived.
     const positionEci = positionAndVelocity.position;


### PR DESCRIPTION
Hi. I am using your great lib, but I had troubles with obsolete / wrong TLE data. Code was crashing with no explanations.

I noticed that the detection of the error wasn't made on the right object (`satellitejs` vs `satrec`).

I also grabbed the actual error messages from `satellite.js` to return them inside the error. It provides a lot more informative error.