### PR TITLE
Fixed clearCache().

### DIFF
--- a/src/sgp4.js
+++ b/src/sgp4.js
@@ -54,8 +54,8 @@ export function getCacheSizes() {
  * Clears SGP caches to free up memory for long-running apps.
  */
 export function clearCache() {
-	caches.forEach((_cache, idx) => {
-		caches[idx] = {};
+	caches.forEach((_cache) => {
+		Object.keys(_cache).forEach(key => delete _cache[key]);
 	});
 }
 


### PR DESCRIPTION
The `clearCache()` function was not implemented correctly, as it simply replaced the references in the `caches` array with empty objects without changing the underlying caches. For example, after calling `clearCache()` the object `cachedSatelliteInfo` would remain unchanged and continue to grow with no way of clearing it.
This fix operates on the underlying cache objects by removing all keys from the cache objects while preserving all references to the caches.