### PR TITLE
fix: :bug: fix getGroundTracks stopping short of antemeridian

### DIFF
--- a/__tests__/sgp4.js
+++ b/__tests__/sgp4.js
@@ -324,7 +324,8 @@ describe("problematic TLES (geosync, decayed)", () => {
 			tle: tleStr,
 			startTimeMS: timestamp
 		});
-		expect(result.length).toEqual(6001);
+		// Time until it reaches the antemeridian
+		expect(result.length).toEqual(172809);
 	});
 
 	test("getGroundTracks", async () => {

--- a/src/sgp4.js
+++ b/src/sgp4.js
@@ -390,10 +390,12 @@ export async function getOrbitTrack({
 	stepMS = 1000,
 	sleepMS = 0,
 	jobChunkSize = 1000,
-	maxTimeMS = 6000000,
+	maxTimeMS,
 	isLngLatFormat = true
 }) {
 	const { tle: tleArr } = parseTLE(tle);
+
+	maxTimeMS ??= getAverageOrbitTimeMS(tleArr) * 1.5;
 
 	const startS = (startTimeMS / 1000).toFixed();
 	const cacheKey = `${tleArr[0]}-${startS}-${stepMS}-${isLngLatFormat}`;


### PR DESCRIPTION
Fixes issue #43 by assuming that a user wants the satellite to go from -180 to +180 longitude by default. Upper limit of 1.5 orbits added to prevent an endless loop.

Maybe it should be up to the user to override the 100 minute default and I will defer to this community, I just wanted to provide a fix based on the orbit vs an arbitrary number like 200 minutes.

