### PR TITLE
Fix incorrect timestamp parameter key for getGroundTracksSync

### DIFF
--- a/__tests__/sgp4.js
+++ b/__tests__/sgp4.js
@@ -257,7 +257,7 @@ describe("getGroundTracksSync", () => {
 	test("1", () => {
 		const coords = getGroundTracksSync({
 			tle: tleArr,
-			optionalTimeMS: 1501039265000
+			startTimeMS: 1501039265000
 		});
 		expect(coords.length).toBe(3);
 
@@ -271,7 +271,7 @@ describe("getGroundTracksSync", () => {
 		const timestamp = 1620583838732;
 		const result = await getGroundTracksSync({
 			tle: proxima2,
-			optionalTimeMS: timestamp
+			startTimeMS: timestamp
 		});
 		expect(result[0][0][0]).toBeCloseTo(-179.65354);
 		expect(result[0][0][1]).toBeCloseTo(84.57353);

--- a/src/sgp4.js
+++ b/src/sgp4.js
@@ -620,7 +620,7 @@ export function getGroundTracks({
 export function getGroundTracksSync({
 	tle,
 	stepMS = 1000,
-	optionalTimeMS = Date.now(), // TODO: change to startTimeMS for consistency
+	startTimeMS = Date.now(),
 	isLngLatFormat = true
 }) {
 	const parsedTLE = parseTLE(tle);
@@ -629,7 +629,7 @@ export function getGroundTracksSync({
 	const orbitTimeMS = getAverageOrbitTimeMS(tleArr);
 	const curOrbitStartMS = getLastAntemeridianCrossingTimeMS(
 		parsedTLE,
-		optionalTimeMS
+		startTimeMS
 	);
 
 	const foundCrossing = curOrbitStartMS !== -1;
@@ -638,7 +638,7 @@ export function getGroundTracksSync({
 
 		const partialGroundTrack = getOrbitTrackSync({
 			tle: parsedTLE,
-			startTimeMS: optionalTimeMS,
+			startTimeMS: startTimeMS,
 			stepMS: _MS_IN_A_MINUTE,
 			maxTimeMS: _MS_IN_A_DAY / 4
 		});


### PR DESCRIPTION
Both the types and documentation indicate that the name should be startTimeMS not optionalTimeMS